### PR TITLE
Update API closest_destination function to handle destination attributes rather than a selected objectstore

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Metascheduler for TPV as Service
 1. Create a venv
 
    ```python
-   
+
    python -m venv .venv
    source .venv/bin/activate
    pip install -r requirements.txt
@@ -52,8 +52,8 @@ Metascheduler for TPV as Service
                "reject": []
                },
                "inherits": null,
-               "context": { 
-                  "latitude": 50.0689816, 
+               "context": {
+                  "latitude": 50.0689816,
                   "longitude": 19.9070188 },
                "rules": {},
                "tags": null
@@ -88,8 +88,8 @@ Metascheduler for TPV as Service
                "reject": []
                },
                "inherits": null,
-               "context": { 
-                  "latitude": 51.9189046, 
+               "context": {
+                  "latitude": 51.9189046,
                   "longitude": 19.1343786 },
                "rules": {},
                "tags": null
@@ -107,7 +107,16 @@ Metascheduler for TPV as Service
                "other_stuff_that_we_find_useful": "foobar"
             }
          },
-         "selected_objectstore": "object_store_poland"
+         "dataset_attributes": {
+            "dataset_italy": {
+               "object_store_id": "object_store_italy_S3_01",
+               "size": 12345678
+            },
+            "dataset_poland": {
+               "object_store_id": "object_store_poland",
+               "size": 123456789
+            }
+         }
       }
       ```
 

--- a/example_tpv_config_locations_api.yml
+++ b/example_tpv_config_locations_api.yml
@@ -22,7 +22,7 @@ tools:
 
       # NOTE: currently object store info is stored in a yaml
       objectstore_loc_path = "tests/fixtures/object_store_locations.yml"
-      dataset_attributes = helpers.get_dataset_attributes(job.get_input_datasets())
+      dataset_attributes = helpers.get_dataset_attributes(job.input_datasets)
 
       yaml=YAML(typ='safe')
       objectstore_file = pathlib.Path(objectstore_loc_path)

--- a/example_tpv_config_locations_api.yml
+++ b/example_tpv_config_locations_api.yml
@@ -20,14 +20,14 @@ tools:
       import pathlib
       from ruamel.yaml import YAML
 
-      # NOTE: currently object store info is stored in a yaml 
+      # NOTE: currently object store info is stored in a yaml
       objectstore_loc_path = "tests/fixtures/object_store_locations.yml"
-      selected_object_store = "object_store_australia"
+      dataset_attributes = helpers.get_dataset_attributes(job.get_input_datasets())
 
       yaml=YAML(typ='safe')
       objectstore_file = pathlib.Path(objectstore_loc_path)
       objectstore_dict = yaml.load(objectstore_file)
-      
+
       # Define the URL of your FastAPI application
       api_url = "http://localhost:8000/process_destinations"
 
@@ -36,7 +36,7 @@ tools:
       input_data = {
         "destinations": candidate_destinations_list,
         "objectstores": objectstore_dict,
-        "selected_objectstore": selected_object_store
+        "dataset_attributes": dataset_attributes
       }
 
       # Send a POST request to the API endpoint
@@ -62,7 +62,6 @@ tools:
       accept:
       reject:
         - offline
-
 
 roles:
   ga_admins:

--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ app = FastAPI()
 class DestinationRequest(BaseModel):
     destinations: List[dict]
     objectstores: Dict[str, dict]
-    selected_objectstore: str
+    dataset_attributes: Dict
 
 
 class ProcessedResult(BaseModel):
@@ -20,7 +20,7 @@ class ProcessedResult(BaseModel):
 @app.post("/process_destinations", response_model=ProcessedResult)
 async def process_destinations(data: DestinationRequest):
 
-    sorted_destinations = closest_destinations(data.destinations, data.objectstores, data.selected_objectstore)
+    sorted_destinations = closest_destinations(data.destinations, data.objectstores, data.dataset_attributes)
 
     return {
         "sorted_destinations": sorted_destinations


### PR DESCRIPTION
This PR updates the API function `closest_destinations` to handle and work with destination attributes instead of the selected objectstore.

The idea is to choose a destination closest to the object store where the dataset is located, i.e., choosing the compute closest to the data or edge computing in other terms.

I have also updated the example and the Readme to reflect the same.

A [PR](https://github.com/galaxyproject/total-perspective-vortex/pull/125) to add a helper function to find/extract the object store ID and the size of the dataset from a job was recently submitted and merged into TPV.

Through this PR, we try to use this helper function to get the object store ID and size of the dataset and send it to the API, and the `closest_destination` function in the API will handle the most basic scenarios,
1. When there is no object store: Returns all destination IDs, and we can fall to the TPVs random weighted sampling method
2. When there is only one dataset
3. When there is more than one dataset and all of them reside in the same object store
4. When there is more than one dataset, and they reside in different object stores

Please double-check the changes in the PR.

**Notes:**
@bgruening suggested in the TPV channel that we could also use the size of the dataset in the decision-making. I have not implemented that in this PR.