### PR TITLE
Add method to get destination queue count example and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ Metascheduler for TPV as Service
                   "latitude": 50.0689816,
                   "longitude": 19.9070188 },
                "rules": {},
-               "tags": null
+               "tags": null,
+               "queued_job_count": 10
             },
             {
                "id": "slurm_poland",
@@ -92,7 +93,8 @@ Metascheduler for TPV as Service
                   "latitude": 51.9189046,
                   "longitude": 19.1343786 },
                "rules": {},
-               "tags": null
+               "tags": null,
+               "queued_job_count": 8
             }
          ],
          "objectstores": {

--- a/example_tpv_config_locations_api.yml
+++ b/example_tpv_config_locations_api.yml
@@ -19,6 +19,7 @@ tools:
       import json
       import pathlib
       from ruamel.yaml import YAML
+      from galaxy import model
 
       # NOTE: currently object store info is stored in a yaml
       objectstore_loc_path = "tests/fixtures/object_store_locations.yml"
@@ -31,7 +32,13 @@ tools:
       # Define the URL of your FastAPI application
       api_url = "http://localhost:8000/process_destinations"
 
-      candidate_destinations_list = [{"id": dest.id, "context": dest.context} for dest in candidate_destinations]
+      # Format the destination data and identify the total number of queued jobs for each destination
+      candidate_destinations_list = []
+      for dest in candidate_destinations:
+        dest_dict = dest.to_dict()
+        dest_dict["queued_job_count"] = app.model.context.query(model.Job).filter(model.Job.state == "queued", model.Job.destination_id == dest.dest_name).count()
+        candidate_destinations_list.append(dest_dict)
+
 
       input_data = {
         "destinations": candidate_destinations_list,


### PR DESCRIPTION
Requested by @abdulrahmanazab during the TPV (WP4) meeting for adding his algorithms to the API.

This lets one fetch the number of jobs in the queued state in a destination of interest by directly querying the Galaxy DB.