### PR TITLE
Update the matchmaking algorithm

### DIFF
--- a/destination_stat.py
+++ b/destination_stat.py
@@ -41,6 +41,7 @@ def query_construction(destination, tool_id):
     queries['dest_unconsumed_cpu_query'] = f"SELECT last(\"unclaimed_cpus\") FROM \"htcondor_cluster_usage\" WHERE \"destination_id\"='{destination}'"
     queries['dest_unconsumed_mem_query'] = f"SELECT last(\"unclaimed_memory\") FROM \"htcondor_cluster_usage\" WHERE \"destination_id\"='{destination}'"
     queries['dest_status'] = f"SELECT last(\"destination_status\") FROM \"htcondor_cluster_usage\" WHERE \"destination_id\"='{destination}'"
+    queries['carbon_intensity_query'] = f"SELECT last(\"carbon_intensity\") FROM \"energy_metrics\" WHERE \"destination_id\"='{destination}'"
 
     return queries
 
@@ -73,6 +74,7 @@ def destination_statistics(influx_client, static_data):
         metrics["dest_unconsumed_cpu"] = get_influx_results(influx_client, queries['dest_unconsumed_cpu_query']) or 0
         metrics["dest_unconsumed_mem"] = get_influx_results(influx_client, queries['dest_unconsumed_mem_query']) or 0
         metrics["dest_status"] = get_influx_results(influx_client, queries['dest_status']) or ""
+        metrics["carbon_intensity"] = get_influx_results(influx_client, queries['carbon_intensity_query']) or 0
         metrics["latitude"] = dest.latitude
         metrics["longitude"] = dest.longitude
 


### PR DESCRIPTION
1. Code cleanup
2. Includes the histogram/binning info from the Pulsars to determine whether there are actually any available compute resources to schedule a job
3. Handles a couple of fallbacks and cases.

Based on the discussions in the issue https://github.com/usegalaxy-eu/tpv-broker/issues/12

This change assumes the following

```
[
  {
    "destination_id": "pulsar_italy",
    "dest_queue_count": 120,
    "dest_run_count": 55,
    "dest_tool_median_queue_time": 30,
    "dest_tool_median_run_time": 120,
    "dest_status": "active",
    "latitude": 50.0689816,
    "longitude": 19.9070188,
    "dest_cpu_histogram": {
        4: 1,
        8: 1,
        16: 1
    },
    "dest_memory_histogram": {
        8: 1,
        16: 1,
        32: 1
    }
  }
]
```

This could be the structure or the data in the variable https://github.com/usegalaxy-eu/tpv-broker/blob/main/destination_stat.py#L61

The new additions are the dest_cpu_histogram and the dest_memory_histogram
They have the format below

```
dest_cpu_histogram ={unclaimed_cpus: count, ...}
dest_memory_histogram ={unclaimed_memory: count, ...}
```

To get there, we need to update and modify the following 2 functions

1. https://github.com/usegalaxy-eu/tpv-broker/blob/main/destination_stat.py#L32
2. https://github.com/usegalaxy-eu/tpv-broker/blob/main/destination_stat.py#L59